### PR TITLE
[Discussion] Remove logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ Get it [here](https://extensions.gnome.org/extension/1253/extended-gestures/)
 	./package.sh
 	```
 	
-## Toubleshooting
+## Troubleshooting
 
 If it is not working, check the following. If it still does not work, please post an issue detailing your laptop model, operating system and gnome shell version
 

--- a/extendedgestures@mpiannucci.github.com/extension.js
+++ b/extendedgestures@mpiannucci.github.com/extension.js
@@ -66,8 +66,6 @@ const TouchpadGestureAction = new Lang.Class({
         if (event.type() != Clutter.EventType.TOUCHPAD_SWIPE)
             return Clutter.EVENT_PROPAGATE;
 
-        global.log('[mpiannucci]', event.get_touchpad_gesture_finger_count())
-
         if (event.get_touchpad_gesture_finger_count() != 3)
             return Clutter.EVENT_PROPAGATE;
 
@@ -166,7 +164,6 @@ const TouchpadGestureAction = new Lang.Class({
             else 
                 index = Main.wm._lookupIndex (windows, focusWindow) - 1;
 
-            global.log(index);
             if (index >= windows.length || index < 0)
                 index = 0;
 


### PR DESCRIPTION
Hey!

When I'm using the three-finger swipe I get a lot of logging, as can be seen below.

```
oct 24 19:43:07 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:07 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:07 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:07 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:07 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:07 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:07 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:07 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
oct 24 19:43:08 gnome-shell[24976]: [mpiannucci], 3
```

These were all consecutively in my system log, nothing else in between.

Personally, I care very little about how many fingers I used to swipe. I do see the value as a debugging tool though.

**If** you decide that the logging should be kept, I recommend:
1. Rate limiting the logging
2. A more informative logging

(There's also a small typo fix in this one.)

Let me know what you think, and I can look into the other solutions.
Cheers!