### PR TITLE
Fix switch workplace for gnome-shell 3.30

### DIFF
--- a/extendedgestures@mpiannucci.github.com/extension.js
+++ b/extendedgestures@mpiannucci.github.com/extension.js
@@ -130,6 +130,11 @@ const TouchpadGestureAction = new Lang.Class({
                 } else if (dir == Meta.MotionDirection.RIGHT) {
                     dir = Meta.MotionDirection.DOWN;
                 }
+                if (!Main.wm._switchData) {
+                  let workspaceManager = global.workspace_manager;
+                  let activeWorkspace = workspaceManager.get_active_workspace();
+                  Main.wm._prepareWorkspaceSwitch(activeWorkspace.index(), -1);
+                }
                 Main.wm._actionSwitchWorkspace(sender, dir);
                 break;
             case 4:


### PR DESCRIPTION
This is just the quick and dirty fix. Actually workspace switching has changed significantly in gnome-shell 3.30: you can now slowly start the switch and cancel again...something that would be nice to copy at some point.
Anyway, this should hopefully not break anything (not tested yet, though, I just hope that path won't be hit) and works on gs 3.29.92 :)