### PR TITLE
Fix switch workplace for gnome-shell <= 3.28

### DIFF
--- a/extendedgestures@mpiannucci.github.com/metadata.json
+++ b/extendedgestures@mpiannucci.github.com/metadata.json
@@ -3,7 +3,7 @@
     "description": "Adds more touchpad gestures into gnome-shell",
     "url": "https://github.com/mpiannucci/gnome-shell-extended-gestures",
     "uuid": "extendedgestures@mpiannucci.github.com", 
-    "shell-version": ["3.26"],
+    "shell-version": ["3.26", "3.28", "3.30"],
     "settings-schema": "org.gnome.shell.extensions.extendedgestures",
     "gettext-domain": "extendedgestures"
 }


### PR DESCRIPTION
73f4846faea72a4d92ba59bbc2ad63e5ed41e608 broke support for older versions. This makes it work in both cases. Fixes #51

Also makes the 3.30er fix work with the new explicit switch actions and makes "show desktop" work with 3.30