### PR TITLE
WIP/DoNotMerge: Use captured-event::nonmotion

### DIFF
--- a/extendedgestures@mpiannucci.github.com/extension.js
+++ b/extendedgestures@mpiannucci.github.com/extension.js
@@ -34,7 +34,7 @@ const TouchpadGestureAction = new Lang.Class({
 
         this._updateSettings();
 
-        this._gestureCallbackID = actor.connect('captured-event', Lang.bind(this, this._handleEvent));
+        this._gestureCallbackID = actor.connect('captured-event::nonmotion', Lang.bind(this, this._handleEvent));
         this._actionCallbackID = this.connect('activated', Lang.bind (this, this._doAction));
         this._updateSettingsCallbackID = schema.connect('changed', Lang.bind(this, this._updateSettings));
     },


### PR DESCRIPTION
From https://gitlab.gnome.org/GNOME/gnome-shell/merge_requests/276:

> This new detail filters out mouse motion events so we don't waste CPU
translating them all into JavaScript handlers that don't care about them.

Requires https://gitlab.gnome.org/GNOME/mutter/merge_requests/283

When the above MRs land we should make use of it so this extension does not push up cpu usage of the GS.
We'll need to add another version check, though. Just posting this PR already so we don't forget :)