### PR TITLE
Advertise support for gnome-shell version 3.32

### DIFF
--- a/extendedgestures@mpiannucci.github.com/metadata.json
+++ b/extendedgestures@mpiannucci.github.com/metadata.json
@@ -1,9 +1,9 @@
 {
-    "name": "Extended Gestures", 
+    "name": "Extended Gestures",
     "description": "Adds more touchpad gestures into gnome-shell",
     "url": "https://github.com/mpiannucci/gnome-shell-extended-gestures",
-    "uuid": "extendedgestures@mpiannucci.github.com", 
-    "shell-version": ["3.26", "3.28", "3.30"],
+    "uuid": "extendedgestures@mpiannucci.github.com",
+    "shell-version": ["3.26", "3.28", "3.30", "3.32"],
     "settings-schema": "org.gnome.shell.extensions.extendedgestures",
     "gettext-domain": "extendedgestures"
 }


### PR DESCRIPTION
It works well here, even on git master.

@mpiannucci: mind merging this and pushing it to https://extensions.gnome.org/ ? The version there is pretty outdated and doesn't have a lot of nice stuff you added.