### PR TITLE
metadata: Advertise support for GS version 3.34

### DIFF
--- a/extendedgestures@mpiannucci.github.com/metadata.json
+++ b/extendedgestures@mpiannucci.github.com/metadata.json
@@ -3,7 +3,7 @@
     "description": "Adds more touchpad gestures into gnome-shell",
     "url": "https://github.com/mpiannucci/gnome-shell-extended-gestures",
     "uuid": "extendedgestures@mpiannucci.github.com",
-    "shell-version": ["3.26", "3.28", "3.30", "3.32"],
+    "shell-version": ["3.26", "3.28", "3.30", "3.32", "3.34"],
     "settings-schema": "org.gnome.shell.extensions.extendedgestures",
     "gettext-domain": "extendedgestures"
 }


### PR DESCRIPTION
Everything seems to work fine here, lets advertise support.

Note: the GS devs are still discussing enabling the version check again, as the recent version had many API changes (and 3.36 will have even more). So better have this in place in advance :)