### PR TITLE
Fix/76/3.36 compatibility

### DIFF
--- a/extendedgestures@mpiannucci.github.com/extension.js
+++ b/extendedgestures@mpiannucci.github.com/extension.js
@@ -38,8 +38,15 @@ const TouchpadGestureAction = new Lang.Class({
         this._actionCallbackID = this.connect('activated', Lang.bind (this, this._doAction));
         this._updateSettingsCallbackID = schema.connect('changed', Lang.bind(this, this._updateSettings));
 
-        let deviceManager = Clutter.DeviceManager.get_default();
-        this._virtualDevice = deviceManager.create_virtual_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
+        if (Clutter.DeviceManager) {
+            // gnome-shell <= 3.34 uses a device manager
+            let deviceManager = Clutter.DeviceManager.get_default();
+            this._virtualDevice = deviceManager.create_virtual_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
+        } else {
+            // gnome-shell >= 3.36 uses a seat
+            let seat = Clutter.get_default_backend().get_default_seat();
+            this._virtualDevice = seat.create_virtual_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
+        }
     },
 
     _checkActivated: function(fingerCount) {

--- a/extendedgestures@mpiannucci.github.com/metadata.json
+++ b/extendedgestures@mpiannucci.github.com/metadata.json
@@ -3,7 +3,7 @@
     "description": "Adds more touchpad gestures into gnome-shell",
     "url": "https://github.com/mpiannucci/gnome-shell-extended-gestures",
     "uuid": "extendedgestures@mpiannucci.github.com",
-    "shell-version": ["3.26", "3.28", "3.30", "3.32", "3.34"],
+    "shell-version": ["3.26", "3.28", "3.30", "3.32", "3.34", "3.36"],
     "settings-schema": "org.gnome.shell.extensions.extendedgestures",
     "gettext-domain": "extendedgestures"
 }


### PR DESCRIPTION
Quoting the commit messages:  
```
fix(TouchpadGestureAction): use seat if device manager is not available

Fixes: https://github.com/mpiannucci/gnome-shell-extended-gestures/issues/76
```

```
docs(*): advertise compatibility for gnome-shell 3.36
```