### PR TITLE
Fix 3.36 compatibility for workspaces actions. Fixes #81

### DIFF
--- a/extendedgestures@mpiannucci.github.com/extension.js
+++ b/extendedgestures@mpiannucci.github.com/extension.js
@@ -196,9 +196,12 @@ const TouchpadGestureAction = new Lang.Class({
         if (!versionSmaller330) {
             let workspaceManager = global.workspace_manager;
             let activeWorkspace = workspaceManager.get_active_workspace();
+            let newWs = activeWorkspace.get_neighbor(dir);
             Main.wm._prepareWorkspaceSwitch(activeWorkspace.index(), -1);
+            Main.wm.actionMoveWorkspace(newWs);
+        } else {
+            Main.wm._actionSwitchWorkspace(sender, dir);
         }
-        Main.wm._actionSwitchWorkspace(sender, dir);
     },
 
     _sendKeyEvent: function (...keys) {


### PR DESCRIPTION
Hello,

This PR uses `actionMoveWorkspace` instead of `_actionSwitchWorkspace` as it was removed in: https://gitlab.gnome.org/GNOME/gnome-shell/-/commit/a8dcfa4656e01764380d081d74365092f08c114e#8ca37e6f0cafc4dac37fcdc428637123f151f516_1157_983 

Fixes #81

Thanks!